### PR TITLE
Improved azure import docs

### DIFF
--- a/docs/integrations/azure/import/active-directory/index.md
+++ b/docs/integrations/azure/import/active-directory/index.md
@@ -1,27 +1,28 @@
 ---
-title: "Import Azure Active Directory into Turbot"
+title: "Import Azure Entra ID into Guardrails"
 template: Documentation
 nav:
-  title: "Active Directory"
+  title: "Entra ID"
   order: 2
 ---
 
-# Import Azure Active Directory into Turbot
+# Import Microsoft Entra ID into Guardrails
 
 [Proper setup in the Azure tenant](integrations/azure/import) is required for
-import of an Azure Active Directory into Turbot.
+import of a Microsoft Entra ID directory into Guardrails. Note that the [azure-activedirectory](https://hub.guardrails.turbot.com/mods/azure/mods/azure-activedirectory) mod is required to
+connect an Entra ID directory.
 
-All child resources of the Azure Active Directory will be discovered and
-subsequently entered into the Turbot CMDB, if permissions allow.
+All child resources of the Microsoft Entra ID directory will be discovered and
+subsequently entered into the Guardrails CMDB.
 
-While you can import an Azure Subscription at the Turbot level, it is
-recommended that you import accounts into Turbot Folders, as it provides greater
+While you can import an Entra ID directory at the Guardrails level, it is
+recommended that you import accounts into Guardrails Folders, as it provides greater
 flexibility and ease of management. Define a Folder hierarchy prior to import.
 
-## Importing Azure Active Directory via Turbot Console (UI)
+## Importing Microsoft Entra ID Directory via Guardrails Console
 
-1. At the main Turbot screen after logging in with `Turbot/Admin` permissions,
-   click the **IMPORT** card in the top right.
+1. On the main Guardrails landing page after logging in with `Turbot/Admin` permissions,
+   click the purple **IMPORT** card in the top right.
 2. Select **Azure Active Directory** on the left.
 3. Use the **Parent Resource** dropdown menu to select where the Azure Active
    Directory will be imported to.
@@ -31,7 +32,7 @@ flexibility and ease of management. Define a Folder hierarchy prior to import.
 5. Congratulations! The active directory is now added as a child resource of the
    folder.
 
-CMDB and Discovery controls are enabled by default and Turbot will begin
+CMDB and Discovery controls are enabled by default and Guardrails will begin
 discovering the resources in the Active Directory. Resources will start
 appearing right away, and resource discovery will continue to run in the
 background.
@@ -42,26 +43,26 @@ Administrators can easily import Active Directory using Terraform. If your
 Terraform environment has not been setup, head on over to the
 [Terraform Setup Page](reference/terraform/setup).
 
-The Turbot Development Kit is a public repository that contains the necessary
-Terraform files to import an Azure Active Directory into Turbot:
+The [Guardrails Samples Repo (GSR)](https://github.com/turbot/guardrails-samples) is a public repository that contains the necessary
+Terraform files to import an Azure Active Directory into Guardrails:
 
 - [Azure Active Directory Import Baseline](https://github.com/turbot/guardrails-samples/tree/master/baselines/azure/azure_active_directory_import)
 
 ```hcl
-# Create the Azure > Active Directory resource in Turbot
+# Create the Azure > Active Directory resource in Guardrails
 # Notice that "id" and tenantId" are the same value
 resource "turbot_resource" "active_directory_resource" {
-  parent = id-of-parent-folder
-  type   = "tmod:@turbot/azure-activedirectory#/resource/types/directory"
-  akas   = ["azure:///directory/${var.azure_active_directory_id}"]
+  parent   = id-of-parent-folder
+  type     = "tmod:@turbot/azure-activedirectory#/resource/types/directory"
+  akas     = ["azure:///directory/${var.azure_active_directory_id}"]
   metadata = jsonencode({
     "azure" : {
       "tenantId" : "your tenant id"  //highlight-line
     }
   })
-  data = jsonencode({
+  data     = jsonencode({
     "id" : "your tenant id" //highlight-line
-    "tenantId": "your tenant id"  //highlight-line
+    "tenantId" : "your tenant id"  //highlight-line
   })
 }
 
@@ -69,24 +70,25 @@ resource "turbot_resource" "active_directory_resource" {
 resource "turbot_policy_setting" "environment" {
   resource = turbot_resource.active_directory_resource.id
   type     = "tmod:@turbot/azure#/policy/types/environment"
-  value    = "Global Cloud" or "US Government" //highlight-line
+  value    = "Global Cloud" 
+  # value    = "US Government" 
 }
 
 resource "turbot_policy_setting" "clientKey" {
-  resource = turbot_resource.active_directory_resource.id
-  type     = "tmod:@turbot/azure#/policy/types/clientKey"
-  value    = "turbot app private client key" //highlight-line
+   resource = turbot_resource.active_directory_resource.id
+   type     = "tmod:@turbot/azure#/policy/types/clientKey"
+   value    = "turbot app private client key" //highlight-line
 }
 
 resource "turbot_policy_setting" "clientId" {
-  resource = turbot_resource.active_directory_resource.id
-  type     = "tmod:@turbot/azure#/policy/types/clientId"
-  value    = "turbot app client id" //highlight-line
+   resource = turbot_resource.active_directory_resource.id
+   type     = "tmod:@turbot/azure#/policy/types/clientId"
+   value    = "turbot app client id" //highlight-line
 }
 
 resource "turbot_policy_setting" "tenantId" {
-  resource = turbot_resource.active_directory_resource.id
-  type     = "tmod:@turbot/azure#/policy/types/tenantId"
-  value    = "your tenant id" //highlight-line
+   resource = turbot_resource.active_directory_resource.id
+   type     = "tmod:@turbot/azure#/policy/types/tenantId"
+   value    = "your tenant id" //highlight-line
 }
 ```

--- a/docs/integrations/azure/import/index.md
+++ b/docs/integrations/azure/import/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Azure Resources into Guardrails"
+title: "Connect Azure Resources to Guardrails"
 template: Documentation
 nav:
   title: "Import Azure Resources"
@@ -10,72 +10,103 @@ nav:
 
 Azure Tenants, Management Groups, Active Directory, and Subscriptions can be
 imported individually if desired, but in each scenario it will require the
-organization to create an App Registration for Guardrails in Entra ID. This allows Guardrails to describe and inventory resources in
-the environment.
+organization to create an App Registration for Guardrails in Entra ID. This allows Guardrails to describe and inventory
+resources in the environment.
 
-Remember that [Mods](mods) enable Turbot to work in the cloud environment. Refer
-to the [Recommended Starting Mods](mods#recommended-starting-mods) for more
-information.
+Remember that [Mods](mods) enable Guardrails to work in the cloud environment. Refer
+to the [Recommended Starting Mods](mods#recommended-starting-mods) for more information.
+
+## Process Overview
+
+Connecting an Azure resource to Guardrails involves a few steps. They are:
+
+1. Create [App Registration](#creating-a-guardrails-app-registration) and [Client Secret](#create-client-secret)
+2. Assign [API Permissions](#microsoft-graph-api-permissions)
+3. Assign [Azure IAM Permissions](#assign-azure-iam-permissions). This may involve creating
+   a [custom Read-Only IAM role](#custom-readonly-iam-role)
+4. [Connect the Azure resource](#connect-azure-resources-to-guardrails) to Guardrails
 
 ## Creating a Guardrails App Registration
 
-An app registration is required to connect any Azure resource to Guardrails. It's the same process to connect tenants, management groups, EntraID Directories or subscriptions.
+An app registration is required to connect any Azure resource to Guardrails. It's the same process to connect tenants,
+management groups, Entra ID Directories or subscriptions.
 
 1. Login to the [Azure portal](https://portal.azure.com/).
 2. Navigate to
    [Azure Active Directory > App Registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps).
 
-   - Click **New registration**.
-   - Name the application. For example, **Guardrails Application**.
-   - Under the **Supported Account Types** option, choose which type of account
-     can access the Guardrails application. Generally, the default option **Accounts
-     in this organizational directory only (Default Directory only - Single
-     tenant)** will be the correct choice. If multiple Azure tenants will need
-     access, select the second option.
-   - Under Redirect URI, select **Web** for the type of application you want to
-     create. Enter the URI of your Guardrails console. After setting the values,
-     select Register.
+    - Click **New registration**.
+    - Name the application. For example, **Guardrails Application**.
+    - Under the **Supported Account Types** option, choose which type of account
+      can access the Guardrails application. Generally, the default option **Accounts
+      in this organizational directory only (Default Directory only - Single
+      tenant)** will be the correct choice. If multiple Azure tenants will need
+      access, select the second option.
+    - Under Redirect URI, select **Web** for the type of application you want to
+      create. Enter the URI of your Guardrails console. After setting the values,
+      select Register.
 
-3. Copy the both the **Directory (tenant) ID** and the **Application (client) ID** from the page that appears after successful creation of the app registration. These strings will be used later when connecting Guardrails to the Azure resource. 
-   
+3. Copy the both the **Directory (tenant) ID** and the **Application (client) ID** from the page that appears after
+   successful creation of the app registration. These strings will be used later when connecting Guardrails to the Azure
+   resource.
 
 ## Create Client Secret
-1. Go to the "Certificats and Secrets" sidebar item. 
+
+1. Go to the "Certificats and Secrets" sidebar item.
 2. Click on the "Client Secrets" tab
-3. Click "+ New client secret".  Provide a description and expiration period that matches organizational policy.
-4. Save the Client Secret Value for later use. The Secret ID is not used by Guardrails. 
-     
+3. Click "+ New client secret". Provide a description and expiration period that matches organizational policy.
+4. Save the Client Secret Value for later use. The Secret ID is not used by Guardrails.
 
 ## Microsoft Graph API Permissions
-API permissions are required when importing a Tenant, Management Group or EntraID Directory.  Skip this section if import a subscription. 
+
+API permissions are required when importing a Tenant, Management Group or EntraID Directory. Skip this section if import
+a subscription.
+
 1. Navigate to the **Azure Active Directory** service, select the Guardrails app registration.
 2. Click **API Permissions** on the left side. If there are any existing permissions,
-   remove them by clicking the three dot menu icon and selecting **Remove
-   Permission**. 
-3. Add the following API Permissions using the **+ Add a
-   permission** button.
+   remove them by clicking the three dot menu icon and selecting **Remove Permission**.
+3. Add the following API Permissions using the **+ Add a permission** button.
 
-   - Microsoft Graph
-     - Application Permissions
-       - Directory
-         - Directory.Read.All (Read directory data)
+    - Microsoft Graph
+        - Application Permissions
+            - Directory
+                - Directory.Read.All (Read directory data)
 
-   **Note**: After adding the above permissions, please remember to grant admin
-   consent by clicking on the button `Grant Admin consent for <directory name>`.
+**Note**: After adding the above permissions, please remember to grant admin
+consent by clicking on the button `Grant Admin consent for <directory name>`.
 
-## Custom IAM Role
-Guardrails 
-A custom role must be created to allow Turbot to manage the Service Principal
-   (App Registration). This can be done easily by utilizing the embedded bash
-   shell in the Azure portal.
+## Which Azure IAM Permissions to Grant
 
-   - Click the Shell icon in the top right, next to the search bar.
-   - Select the `Bash` option. If an option is not presented, ensure that bash
-     is selected in the dropdown menu in the top left of the shell.
-   - Create and open a JSON file using the text editor of choice. For example,
-     enter `vim turbot_role.json` into the shell terminal then hit enter.
-   - Copy paste the JSON below into the new text file. Be sure to add the
-     **Tenant ID** to this text in the AssignableScopes attribute.
+The Azure permissions granted to Guardrails depend completely on the organization's requirements. The table below shows
+the permissions recommended for various levels of Guardrails interaction with Azure resources.
+
+| **Guardrails Mode**      | **Required Permission**   | **Description**                                         |
+|--------------------------|---------------------------|---------------------------------------------------------|
+| Read/Write + Permissions | Owner                     | Detective controls, enforcements and manage permissions |
+| Read/Write               | Contributor               | Detective controls and enforcements                     |
+| Read/Write               | Contributor               | Detective controls and enforcements                     |
+| Read-Only                | Reader and/or Custom Role | Detective controls                                      |
+
+Turbot recommends that organizations craft a custom role to meet their individual least privilege requirements. The
+Read-Only custom role described below should be used as a baseline.
+
+## Custom ReadOnly IAM Role
+
+The default `Reader` RBAC provides broad read-only access to all Azure resource types. However, there are few
+permissions that Guardrails needs to inventory all resource types. The custom role described below grants read-only
+access plus the extra permissions.
+
+### Create the Role
+
+The Read-Only custom role can be created easily in the embedded bash shell in the Azure portal.
+
+- Click the Shell icon in the top right, next to the search bar.
+- Select the `Bash` option. If an option is not presented, ensure that bash
+  is selected in the dropdown menu in the top left of the shell.
+- Create and open a JSON file using the text editor of choice. For example,
+  enter `vim guardrails-readonly.json` into the shell terminal then hit enter.
+- Paste the JSON below into the new text file. Be sure to add the
+  **Tenant ID** to this text in the AssignableScopes attribute.
 
 ```json
  {
@@ -103,75 +134,8 @@ A custom role must be created to allow Turbot to manage the Service Principal
 }
 ```
 
-   - To create the role, copy the bash command
-     `az role definition create --role-definition &lt;name.json&gt;` into the
-     shell, changing &lt;name.json&gt; to the name of the file created in the
-     previous step. Hit enter to create the role.
-
-6. This new role must be assigned in the **Tenant Root Group**. This can only be
-   done if the logged in user has **Access management for Azure resources**
-   option set to **Yes**. If there is any question if a global administrator has
-   the correct access, refer to Microsoft's
-   [guide on elevating access for a Global Administrator](https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).
-   If permissions had to be assigned, be sure to log out and log back in to
-   refresh the permission set.
-    - Once access has been verified, navigate to the **Management groups**
-      application in the Azure portal.
-    - Next to the title **Tenant Root Group**, the word **details** should be
-      clickable. If not, wait for a few minutes as permissions can take some time
-      to propagate.
-    - Select the **Access control (IAM)** tab on the left side.
-    - Towards the top left, click **+ Add** and select the **Add Role
-      Assignment** option. This opens a new overlay on the right side.
-    - In the **Role** dropdown, type the title of the role created in step 5.
-      Note that this search is case-sensitive!
-    - Leave the **Assign access to** field as default, then search for the Turbot
-      Service principal (App registration) that was created in step 2.
-    - Click **Save** at the bottom to confirm the role assignment.
-
-The role grants access to Guardrails for discovering Management groups and
-Subscriptions. Guardrails will also need grants to access Subscription resources,
-which can be done at Tenant, Management Group, as well as the individual
-subscription level. Depending on the control objectives of the organization, the
-required role(s) will vary.
-
-| **Turbot Mode**          | **Real-Time Events** | **Required Permission** | **Description**                                         |
-| ------------------------ | -------------------- | ----------------------- | ------------------------------------------------------- |
-| Read/Write + Permissions | Event Handler        | Owner                   | Detective controls, enforcements and manage permissions |
-| Read/Write               | Event Handler        | Contributor             | Detective controls and enforcements                     |
-| Read/Write               | Event Poller         | Contributor             | Detective controls and enforcements                     |
-| Read-Only                | Event Handler        | Reader + Custom Role    | Detective controls                                      |
-| Read-Only                | Event Poller         | Reader + Custom Role    | Detective controls                                      |
-
-#### Custom Read-only Role
-
-Notice that for **Read-Only** mode, a custom role is required. Below is an
-example of a role that would allow Turbot to discover resources in Azure, but
-not make changes:
-
-```json
-{
-  "Name": "turbot_reader",
-  "Description": "Basic Permissions needed for Reader access",
-  "Actions": [
-    "*/read",
-    "Microsoft.Storage/storageAccounts/listkeys/action",
-    "Microsoft.KeyVault/vaults/secrets/read",
-    "Microsoft.KeyVault/vaults/read"
-  ],
-  "NotActions": [],
-  "DataActions": [],
-  "NotDataActions": [],
-  "AssignableScopes": [
-    "/providers/Microsoft.Management/managementGroups/<<Tenant ID>>"
-      ## OR ##
-    "subscriptions/<<Subscription ID>>"
-  ]
-}
-```
-
-For those who do not wish to grant `storageAccounts/listkeys`, set the
-[Azure > Storage > Queue > CMDB](/guardrails/docs/mods/azure/azure-storage/policy#azure--storage--queue--cmdb)
+Note: For those who do not wish to grant `storageAccounts/listkeys`, set the
+[Azure > Storage > Queue > CMDB](https://hub.guardrails.turbot.com/mods/azure/policies/azure-storage/queueCmdb)
 policy to `Skip` to avoid discovery errors. Queue discovery and management is
 not possible without `listkeys` permissions.
 
@@ -179,11 +143,37 @@ Review the documentation for
 [Azure custom roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles)
 for the various different ways a custom role can be created.
 
-**Note**: All child resources will inherit any access granted on parent
-resources.
+- To create the role, run this command `az role definition create --role-definition guardrails-readonly.json` in the
+  shell.
+
+### Assign Azure IAM Permissions
+
+The user provisioning Guardrails IAM permissions should have the **Access management for Azure resources**
+option set to **Yes**. If there is any question if a global administrator has
+the correct access, refer to Microsoft's
+[guide on elevating access for a Global Administrator](https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).
+If permissions had to be assigned, be sure to log out and log back in to
+refresh the permission set.
+
+- Once access has been verified, navigate to the target Tenant, Management Group or Subscription
+  application in the Azure portal.
+- Select the **Access control (IAM)** tab on the left side.
+- Towards the top left, click **+ Add** and select the **Add Role
+  Assignment** option. This opens a new overlay on the right side.
+- In the **Role** dropdown, type the title of the role created in step 5.
+  Note that this search is case-sensitive!
+- Leave the **Assign access to** field as default, then search for the Guardrails app registration that was created in
+  step 2.
+- Click **Save** at the bottom to confirm the role assignment.
+
+**Note**: All child resources will inherit any access granted on parent resources. For example, granting `Reader` to
+the Azure tenant grants the same permissions to all management groups and subscriptions.
 
 ## Connect Guardrails to Azure
-Now 
+
+With the App registration, API permissions and Azure IAM permissions, you're ready to connect the Azure resource to
+Guardrails. Follow the appropriate instructions below.
+
 - [Connect Tenant](integrations/azure/import/tenant)
 - [Connect Management Group](integrations/azure/import/management-group)
 - [Connect Active Directory](integrations/azure/import/active-directory)

--- a/docs/integrations/azure/import/index.md
+++ b/docs/integrations/azure/import/index.md
@@ -1,94 +1,71 @@
 ---
-title: "Import Azure Resources into Turbot"
+title: "Connect Azure Resources into Guardrails"
 template: Documentation
 nav:
   title: "Import Azure Resources"
   order: 1
 ---
 
-# Import Azure Resources into Turbot
+# Connect Azure Resources to Guardrails
 
 Azure Tenants, Management Groups, Active Directory, and Subscriptions can be
 imported individually if desired, but in each scenario it will require the
-organization to create a **Turbot Service Principal**, also known as an **App
-Registration** in Active Directory. This allows Turbot to describe resources in
+organization to create an App Registration for Guardrails in Entra ID. This allows Guardrails to describe and inventory resources in
 the environment.
-
-Once the Service Principal is created and required permissions are set, Tenants,
-Management Groups, Active Directory, and Subscriptions can be imported into
-Turbot.
-
-- [Tenant](integrations/azure/import/tenant)
-- [Management Group](integrations/azure/import/management-group)
-- [Active Directory](integrations/azure/import/active-directory)
-- [Subscriptions](integrations/azure/import/subscription)
 
 Remember that [Mods](mods) enable Turbot to work in the cloud environment. Refer
 to the [Recommended Starting Mods](mods#recommended-starting-mods) for more
 information.
 
-## Creating a Turbot Service Principal (App Registration)
+## Creating a Guardrails App Registration
 
-Before importing an Azure Tenant, a service principal must be created with the
-appropriate access. This is also known as an **App Registration**.
+An app registration is required to connect any Azure resource to Guardrails. It's the same process to connect tenants, management groups, EntraID Directories or subscriptions.
 
 1. Login to the [Azure portal](https://portal.azure.com/).
 2. Navigate to
    [Azure Active Directory > App Registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps).
 
    - Click **New registration**.
-   - Name the application. For example, **Turbot Application**.
+   - Name the application. For example, **Guardrails Application**.
    - Under the **Supported Account Types** option, choose which type of account
-     can access the Turbot application. Generally, the default option **Accounts
+     can access the Guardrails application. Generally, the default option **Accounts
      in this organizational directory only (Default Directory only - Single
      tenant)** will be the correct choice. If multiple Azure tenants will need
      access, select the second option.
    - Under Redirect URI, select **Web** for the type of application you want to
-     create. Enter the URI of your Turbot console. After setting the values,
+     create. Enter the URI of your Guardrails console. After setting the values,
      select Register.
 
-3. It is necessary to pass both the **Directory (tenant) ID** as well as the
-   **Application (client) ID** and secret into Turbot for authentication. These
-   strings can be found using the following steps.
+3. Copy the both the **Directory (tenant) ID** and the **Application (client) ID** from the page that appears after successful creation of the app registration. These strings will be used later when connecting Guardrails to the Azure resource. 
+   
 
-   - Directory (tenant) ID and Application (client) ID:
-     - Select **Azure Active Directory**.
-     - Navigate to the new application by going to the **Azure Active
-       Directory** -> **App registrations** page.
-     - Copy the **Directory (tenant) ID** and store it in a temporary text file.
-     - Copy the **Application (client) ID** and store it in a temporary text
-       file.
-   - Client Secret:
-     - Select **Azure Active Directory**.
-     - Navigate to the new application by going to the **Azure Active
-       Directory** -> **App registrations** page.
-     - Click on **Certificates and Secrets**.
-     - Create the **New client Secret** button.
-     - After adding the client secret, the value of the client secret is
-       displayed. Copy this value and store it in a temporary text file. The
-       secret will be hidden after leaving this page. If the secret is lost,
-       simply delete the existing one and create a new one.
+## Create Client Secret
+1. Go to the "Certificats and Secrets" sidebar item. 
+2. Click on the "Client Secrets" tab
+3. Click "+ New client secret".  Provide a description and expiration period that matches organizational policy.
+4. Save the Client Secret Value for later use. The Secret ID is not used by Guardrails. 
+     
 
-4. API permissions in the Turbot application must be assigned. Navigate to the
-   **Azure Active Directory** service, select the Turbot application, then click
-   **API Permissions** on the left side. If there are any existing permissions,
+## Microsoft Graph API Permissions
+API permissions are required when importing a Tenant, Management Group or EntraID Directory.  Skip this section if import a subscription. 
+1. Navigate to the **Azure Active Directory** service, select the Guardrails app registration.
+2. Click **API Permissions** on the left side. If there are any existing permissions,
    remove them by clicking the three dot menu icon and selecting **Remove
-   Permission**. Add the following API Permissions using the **+ Add a
+   Permission**. 
+3. Add the following API Permissions using the **+ Add a
    permission** button.
 
    - Microsoft Graph
      - Application Permissions
-       - AuditLog
-         - AuditLog.Read.All (Read all audit log data)
        - Directory
          - Directory.Read.All (Read directory data)
-       - Organization
-         - Organization.Read.All (Read organization information)
 
    **Note**: After adding the above permissions, please remember to grant admin
    consent by clicking on the button `Grant Admin consent for <directory name>`.
 
-5. A custom role must be created to allow Turbot to manage the Service Principal
+## Custom IAM Role
+Guardrails 
+A custom role must be created to allow Turbot to manage the Service Principal
    (App Registration). This can be done easily by utilizing the embedded bash
    shell in the Azure portal.
 
@@ -100,18 +77,31 @@ appropriate access. This is also known as an **App Registration**.
    - Copy paste the JSON below into the new text file. Be sure to add the
      **Tenant ID** to this text in the AssignableScopes attribute.
 
-   ```json
-   {
-     "Name": "Turbot Management Group Role",
-     "IsCustom": true,
-     "Description": "Used by Turbot for Tenant Import",
-     "Actions": ["Microsoft.Management/getEntities/action"],
-     "NotActions": [],
-     "AssignableScopes": [
-       "/providers/Microsoft.Management/managementGroups/<<Tenant ID>>"
-     ]
-   }
-   ```
+```json
+ {
+  "properties": {
+    "roleName": "Guardrails ReadOnly Role",
+    "description": "Used by Guardrails for ReadOnly Access to Azure resources",
+    "assignableScopes": [
+      "/providers/Microsoft.Management/managementGroups/<<Tenant ID>>"
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "*/read",
+          "Microsoft.Management/getEntities/action",
+          "Microsoft.Storage/storageAccounts/listkeys/action",
+          "Microsoft.KeyVault/vaults/secrets/read",
+          "Microsoft.KeyVault/vaults/read"
+        ],
+        "notActions": [],
+        "dataActions": [],
+        "notDataActions": []
+      }
+    ]
+  }
+}
+```
 
    - To create the role, copy the bash command
      `az role definition create --role-definition &lt;name.json&gt;` into the
@@ -125,27 +115,25 @@ appropriate access. This is also known as an **App Registration**.
    [guide on elevating access for a Global Administrator](https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).
    If permissions had to be assigned, be sure to log out and log back in to
    refresh the permission set.
-   - Once access has been verified, navigate to the **Management groups**
-     application in the Azure portal.
-   - Next to the title **Tenant Root Group**, the word **details** should be
-     clickable. If not, wait for a few minutes as permissions can take some time
-     to propagate.
-   - Select the **Access control (IAM)** tab on the left side.
-   - Towards the top left, click **+ Add** and select the **Add Role
-     Assignment** option. This opens a new overlay on the right side.
-   - In the **Role** dropdown, type the title of the role created in step 5.
-     Note that this search is case sensitive!
-   - Leave the **Assign access to** field as default, then search for the Turbot
-     Service principal (App registration) that was created in step 2.
-   - Click **Save** at the bottom to confirm the role assignment.
+    - Once access has been verified, navigate to the **Management groups**
+      application in the Azure portal.
+    - Next to the title **Tenant Root Group**, the word **details** should be
+      clickable. If not, wait for a few minutes as permissions can take some time
+      to propagate.
+    - Select the **Access control (IAM)** tab on the left side.
+    - Towards the top left, click **+ Add** and select the **Add Role
+      Assignment** option. This opens a new overlay on the right side.
+    - In the **Role** dropdown, type the title of the role created in step 5.
+      Note that this search is case-sensitive!
+    - Leave the **Assign access to** field as default, then search for the Turbot
+      Service principal (App registration) that was created in step 2.
+    - Click **Save** at the bottom to confirm the role assignment.
 
-### Final Step: Turbot Mode
-
-The role grants access to Turbot for discovering Management groups and
-Subscriptions. Turbot will also need grants to access Subscription resources,
+The role grants access to Guardrails for discovering Management groups and
+Subscriptions. Guardrails will also need grants to access Subscription resources,
 which can be done at Tenant, Management Group, as well as the individual
 subscription level. Depending on the control objectives of the organization, the
-required role(s) will vary:
+required role(s) will vary.
 
 | **Turbot Mode**          | **Real-Time Events** | **Required Permission** | **Description**                                         |
 | ------------------------ | -------------------- | ----------------------- | ------------------------------------------------------- |
@@ -193,3 +181,10 @@ for the various different ways a custom role can be created.
 
 **Note**: All child resources will inherit any access granted on parent
 resources.
+
+## Connect Guardrails to Azure
+Now 
+- [Connect Tenant](integrations/azure/import/tenant)
+- [Connect Management Group](integrations/azure/import/management-group)
+- [Connect Active Directory](integrations/azure/import/active-directory)
+- [Connect Subscriptions](integrations/azure/import/subscription)

--- a/docs/integrations/azure/import/management-group/index.md
+++ b/docs/integrations/azure/import/management-group/index.md
@@ -1,27 +1,27 @@
 ---
-title: "Import Azure Management Group into Turbot"
+title: "Import Azure Management Group into Guardrails"
 template: Documentation
 nav:
   title: "Management Group"
   order: 3
 ---
 
-# Import Azure Management Group into Turbot
+# Import Azure Management Group into Guardrails
 
 [Proper setup in the Azure tenant](integrations/azure/import) is required for
-import of an Azure Management Group into Turbot.
+import of an Azure Management Group into Guardrails.
 
 All child resources of the Management Group in Azure will be discovered and
-subsequently entered into the Turbot CMDB, if permissions allow.
+subsequently entered into the Guardrails CMDB.
 
 While you can import an Azure Management Group at the Turbot level, it is
-recommended that you import accounts into Turbot Folders, as it provides greater
+recommended that you import accounts into Guardrails Folders, as it provides greater
 flexibility and ease of management. Define a Folder hierarchy prior to import.
 
-## Importing Azure Management Group via Turbot Console (UI)
+## Importing Azure Management Group via Guardrails Console
 
-1. At the main Turbot screen after logging in with `Turbot/Admin` permissions,
-   click the **IMPORT** card in the top right.
+1. At the main Guardrails screen after logging in with `Turbot/Admin` permissions,
+   click the purple **IMPORT** card in the top right.
 2. Select **Azure Management Group** on the left.
 3. Use the **Parent Resource** dropdown menu to select where the Azure
    Management Group will be imported to.
@@ -31,29 +31,16 @@ flexibility and ease of management. Define a Folder hierarchy prior to import.
 5. Congratulations! The management group is now added as a child resource of the
    folder.
 
-CMDB and Discovery controls are enabled by default and Turbot will begin
+CMDB and Discovery controls are enabled by default and Guardrails will begin
 discovering the resources in the Azure Management Group. Resources will start
 appearing right away, and resource discovery will continue to run in the
 background.
 
 ## Management Group Event Pollers
 
-To ensure that Turbot receives events such as new subscriptions in the
-management group, ensure that Management Group event pollers are enabled. Do
-this by:
+Guardrails uses Management Group event pollers to detect new, updated or deleted subscriptions in the
+management group.  Management Group event pollers are enabled by default. No action is required. 
 
-1. Go to a level high enough in the resource hierarchy to affect all imported
-   Management Groups.
-2. Create a new policy setting for
-   [Azure > Turbot > Management Group Event Poller](https://turbot.com/guardrails/docs/mods/azure/azure/policy#azure--turbot--management-group-event-poller)
-   then set it to `Enabled`
-3. Management Group event polling will kick off. Ensure correct operation by
-   checking the
-   [Management Group Event Poller](https://turbot.com/guardrails/docs/mods/azure/azure/control#azure--turbot--management-group-event-poller)
-   control in at least one Management Group. The default interval is every 12
-   hours but can be as little as one hour with the
-   [Azure > Turbot > Management Group Event Poller > Interval](https://turbot.com/guardrails/docs/mods/azure/azure/policy#azure--turbot--management-group-event-poller--interval)
-   policy.
 
 ## Import Management Group via Terraform
 
@@ -61,13 +48,13 @@ Administrators can easily import Management Group using Terraform. If your
 Terraform environment has not been setup, head on over to the
 [Terraform Setup Page](reference/terraform/setup).
 
-The Turbot Development Kit is a public repository that contains the necessary
-Terraform files to import a Management Group into Turbot:
+The [Guardrails Samples Repo (GSR)](https://github.com/turbot/guardrails-samples)  is a public repository that contains the necessary
+Terraform files to import a Management Group into Guardrails:
 
 - [Azure Management Group Import Baseline](https://github.com/turbot/guardrails-samples/tree/master/baselines/azure/azure_management_group_import)
 
 ```hcl
-# Create the Azure > Management Group resource in Turbot
+# Create the Azure > Management Group resource in Guardrails
 resource "turbot_resource" "management_group_resource" {
   parent = var.parent_resource
   type   = "tmod:@turbot/azure#/resource/types/managementGroup"
@@ -84,7 +71,7 @@ resource "turbot_resource" "management_group_resource" {
   })
 }
 
-# Set the credentials for the Management Group via Turbot policies
+# Set the credentials for the Management Group via Guardrails policies
 
 resource "turbot_policy_setting" "environment" {
   resource = turbot_resource.management_group_resource.id

--- a/docs/integrations/azure/import/subscription/index.md
+++ b/docs/integrations/azure/import/subscription/index.md
@@ -1,12 +1,12 @@
 ---
-title: "Import Azure Subscription into Turbot"
+title: "Import Azure Subscription into Guardrails"
 template: Documentation
 nav:
   title: "Subscription"
   order: 4
 ---
 
-# Import Azure Subscription into Turbot
+# Import Azure Subscription into Guardrails
 
 [Proper setup in the Azure tenant](integrations/azure/import) is required for
 import of an Azure Subscription into a Guardrails workspace.
@@ -28,7 +28,7 @@ flexibility and ease of management. Define a Folder hierarchy prior to import.
 5. Congratulations! The subscription is now added as a child resource of the
    folder.
 
-CMDB and Discovery controls are enabled by default and Turbot will begin
+CMDB and Discovery controls are enabled by default and Guardrails will begin
 discovering the resources in the Azure Subscription. Resources will start
 appearing right away, and resource discovery will continue to run in the
 background.
@@ -39,19 +39,19 @@ Administrators can easily import subscriptions using Terraform. If your
 Terraform environment has not been set up, head on over to the
 [Terraform Setup Page](reference/terraform/setup).
 
-The Guardrails-Samples Repo is a public repository that contains the necessary
-Terraform files to import an Azure Subscription into Turbot:
+The [Guardrails Samples Repo (GSR)](https://github.com/turbot/guardrails-samples)  is a public repository that contains the necessary
+Terraform files to import an Azure Subscription into Guardrails:
 
 - [Azure Subscription Import Baseline](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_import)
 
 Note that the linked baseline is for existing Azure subscriptions, but there are
 also baselines available that:
 
-- [Create an Azure subscription and import into Turbot](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_create_then_import)
-- [Create an Azure subscription and import into Turbot with Read Only rights](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_create_then_import_ro)
+- [Create an Azure subscription and import into Guardrails](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_create_then_import)
+- [Create an Azure subscription and import into Guardrails with Read Only rights](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_create_then_import_ro)
 
 ```hcl
-# Create the Azure > Subscription resource in Turbot
+# Create the Azure > Subscription resource in Guardrails
 resource "turbot_resource" "subscription_resource" {
   parent = var.parent_resource
   type   = "tmod:@turbot/azure#/resource/types/subscription"
@@ -66,7 +66,7 @@ resource "turbot_resource" "subscription_resource" {
   })
 }
 
-# Set the credentials for the subscription via Turbot policies
+# Set the credentials for the subscription via Guardrails policies
 # Azure > Environment
 resource "turbot_policy_setting" "environment" {
   resource = turbot_resource.subscription_resource.id

--- a/docs/integrations/azure/import/subscription/index.md
+++ b/docs/integrations/azure/import/subscription/index.md
@@ -9,15 +9,15 @@ nav:
 # Import Azure Subscription into Turbot
 
 [Proper setup in the Azure tenant](integrations/azure/import) is required for
-import of an Azure Subscription into Turbot.
+import of an Azure Subscription into a Guardrails workspace.
 
 While you can import an Azure Subscription at the Turbot level, it is
-recommended that you import accounts into Turbot Folders, as it provides greater
+recommended that you import accounts into Guardrails Folders, as it provides greater
 flexibility and ease of management. Define a Folder hierarchy prior to import.
 
-## Import Azure Subscription via Turbot Console (UI)
+## Import Azure Subscription via Guardrails Console
 
-1. At the main Turbot screen after logging in with `Turbot/Admin` permissions,
+1. On the Guardrails landing page after logging in with `Turbot/Admin` permissions,
    click the **IMPORT** card in the top right.
 2. Select **Azure Subscription** on the left.
 3. Use the **Parent Resource** dropdown menu to select where the Azure
@@ -36,19 +36,19 @@ background.
 ## Import Subscription via Terraform
 
 Administrators can easily import subscriptions using Terraform. If your
-Terraform environment has not been setup, head on over to the
+Terraform environment has not been set up, head on over to the
 [Terraform Setup Page](reference/terraform/setup).
 
-The Turbot Development Kit is a public repository that contains the necessary
+The Guardrails-Samples Repo is a public repository that contains the necessary
 Terraform files to import an Azure Subscription into Turbot:
 
-- [Azure Subscription Import Baseline](https://github.com/turbot/guardrails-samples/tree/master/baselines/azure/azure_sub_import)
+- [Azure Subscription Import Baseline](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_import)
 
 Note that the linked baseline is for existing Azure subscriptions, but there are
 also baselines available that:
 
-- [Create an Azure subscription and import into Turbot](https://github.com/turbot/guardrails-samples/tree/master/baselines/azure/azure_sub_create_then_import)
-- [Create an Azure subscription and import into Turbot with Read Only rights](https://github.com/turbot/guardrails-samples/tree/master/baselines/azure/azure_sub_create_then_import_ro)
+- [Create an Azure subscription and import into Turbot](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_create_then_import)
+- [Create an Azure subscription and import into Turbot with Read Only rights](https://github.com/turbot/guardrails-samples/tree/main/baselines/azure/azure_sub_create_then_import_ro)
 
 ```hcl
 # Create the Azure > Subscription resource in Turbot
@@ -57,12 +57,12 @@ resource "turbot_resource" "subscription_resource" {
   type   = "tmod:@turbot/azure#/resource/types/subscription"
   metadata = jsonencode({
     "azure" : {
-      "subscriptionId" : "your subscription id", //highlight-line
-      "tenantId" : "your tenant id" //highlight-line
+      "subscriptionId" : "{your subscription id}", //highlight-line
+      "tenantId" : "{your tenant id}" //highlight-line
     }
   })
   data = jsonencode({
-    "subscriptionId" : "your subscription id" //highlight-line
+    "subscriptionId" : "{your subscription id}" //highlight-line
   })
 }
 
@@ -71,24 +71,25 @@ resource "turbot_resource" "subscription_resource" {
 resource "turbot_policy_setting" "environment" {
   resource = turbot_resource.subscription_resource.id
   type     = "tmod:@turbot/azure#/policy/types/environment"
-  value    = "Global Cloud" or "US Government" //highlight-line
+  value    = "Global Cloud"
+  # value    = "US Government" 
 }
 # Azure > Client Key
 resource "turbot_policy_setting" "clientKey" {
   resource = turbot_resource.subscription_resource.id
   type     = "tmod:@turbot/azure#/policy/types/clientKey"
-  value    = "turbot application client key" //highlight-line
+  value    = "{turbot application client key}" 
 }
 # Azure > Client ID
 resource "turbot_policy_setting" "clientId" {
   resource = turbot_resource.subscription_resource.id
   type     = "tmod:@turbot/azure#/policy/types/clientId"
-  value    = "turbot application client id" //highlight-line
+  value    = "{turbot application client id}" 
 }
 # Azure > Tenant ID
 resource "turbot_policy_setting" "tenantId" {
   resource = turbot_resource.subscription_resource.id
   type     = "tmod:@turbot/azure#/policy/types/tenantId"
-  value    = "your tenant id" //highlight-line
+  value    = "{your tenant id}" //highlight-line
 }
 ```

--- a/docs/integrations/azure/import/tenant/index.md
+++ b/docs/integrations/azure/import/tenant/index.md
@@ -1,26 +1,26 @@
 ---
-title: "Import Azure Tenant into Turbot"
+title: "Import Azure Tenant into Guardrails"
 template: Documentation
 nav:
   title: "Tenant"
   order: 1
 ---
 
-# Import Azure Tenant into Turbot
+# Import Azure Tenant into Guardrails
 
 [Proper setup in the Azure tenant](integrations/azure/import) is required for
-import of an Azure Tenant into Turbot.
+import of an Azure Tenant into Guardrails.
 
 All child resources of the Azure Tenant will be discovered and subsequently
-entered into the Turbot CMDB, if permissions allow.
+entered into the Guardrails CMDB.
 
 While you can import an Azure Tenant at the Turbot level, it is recommended that
-you import accounts into Turbot Folders, as it provides greater flexibility and
+you import accounts into Guardrails Folders, as it provides greater flexibility and
 ease of management. Define a Folder hierarchy prior to import.
 
-## Import Azure Tenant via Turbot Console (UI)
+## Import Azure Tenant via Guardrails Console
 
-1. At the main Turbot screen after logging in with `Turbot/Admin` permissions,
+1. At the main Guardrails landing page after logging in with `Turbot/Admin` permissions,
    click the purple **IMPORT** card in the top right corner.
 2. Select **Azure Tenant** on the left.
 3. Use the **Parent Resource** dropdown menu to select the parent resource for the Azure Tenant.
@@ -29,27 +29,15 @@ ease of management. Define a Folder hierarchy prior to import.
    **Import**.
 5. Congratulations! The tenant is now added as a child resource of the folder.
 
-CMDB and Discovery controls are enabled by default and Turbot will begin
+CMDB and Discovery controls are enabled by default and Guardrails will begin
 discovering the resources in the Azure Tenant. Resources will start appearing
 right away, and resource discovery will continue to run in the background.
 
 ## Management Group Event Pollers
 
-To ensure that Turbot receives events such as new subscriptions in the
-management groups inside the tenant, ensure that Management Group event pollers
-are enabled. Do this by:
+Guardrails uses Management Group event pollers to detect new, updated or deleted subscriptions in the
+management group.  Management Group event pollers are enabled by default. No action is required. 
 
-1. Go to the tenant or to a folder above the tenant.
-2. Create a new policy setting for
-   [Azure > Turbot > Management Group Event Poller](https://turbot.com/guardrails/docs/mods/azure/azure/policy#azure--turbot--management-group-event-poller)
-   then set it to `Enabled`
-3. Management Group event polling will kick off. Ensure correct operation by
-   checking the
-   [Management Group Event Poller](https://turbot.com/guardrails/docs/mods/azure/azure/control#azure--turbot--management-group-event-poller)
-   control in at least one Management Group. The default interval is every 12
-   hours but can be as little as one hour with the
-   [Azure > Turbot > Management Group Event Poller > Interval](https://turbot.com/guardrails/docs/mods/azure/azure/policy#azure--turbot--management-group-event-poller--interval)
-   policy.
 
 ## Import Tenant via Terraform
 
@@ -57,13 +45,13 @@ Administrators can easily import tenant using Terraform. If your Terraform
 environment has not been setup, head on over to the
 [Terraform Setup Page](reference/terraform/setup).
 
-The Turbot Development Kit is a public repository that contains the necessary
-Terraform files to import an Azure Tenant into Turbot:
+The [Guardrails Samples Repo (GSR)](https://github.com/turbot/guardrails-samples)  is a public repository that contains the necessary
+Terraform files to import an Azure Tenant into Guardrails:
 
 - [Azure Tenant Import Baseline](https://github.com/turbot/guardrails-samples/tree/master/baselines/azure/azure_tenant_import)
 
 ```hcl
-# Create the Azure > Tenant resource in Turbot
+# Create the Azure > Tenant resource in Guardrails
 resource "turbot_resource" "tenant_resource" {
   parent = var.parent_resource
   type   = "tmod:@turbot/azure#/resource/types/tenant"
@@ -78,7 +66,7 @@ resource "turbot_resource" "tenant_resource" {
   })
 }
 
-# Set the credentials for the Tenant via Turbot policies
+# Set the credentials for the Tenant via Guardrails policies
 
 resource "turbot_policy_setting" "environment" {
   resource = turbot_resource.tenant_resource.id

--- a/docs/integrations/azure/import/tenant/index.md
+++ b/docs/integrations/azure/import/tenant/index.md
@@ -21,10 +21,9 @@ ease of management. Define a Folder hierarchy prior to import.
 ## Import Azure Tenant via Turbot Console (UI)
 
 1. At the main Turbot screen after logging in with `Turbot/Admin` permissions,
-   click the **IMPORT** card in the top right.
+   click the purple **IMPORT** card in the top right corner.
 2. Select **Azure Tenant** on the left.
-3. Use the **Parent Resource** dropdown menu to select where the Azure Tenant
-   will be imported to.
+3. Use the **Parent Resource** dropdown menu to select the parent resource for the Azure Tenant.
 4. Enter the **Tenant (directory) ID**, **Client (application) ID**, and
    **Client Key (secret)**, as well as the **Environment** type then click
    **Import**.
@@ -84,24 +83,25 @@ resource "turbot_resource" "tenant_resource" {
 resource "turbot_policy_setting" "environment" {
   resource = turbot_resource.tenant_resource.id
   type     = "tmod:@turbot/azure#/policy/types/environment"
-  value    = "Global Cloud" or "US Government" //highlight-line
+  value    = "Global Cloud" 
+  # value    = "US Government"
 }
 
 resource "turbot_policy_setting" "clientKey" {
   resource = turbot_resource.tenant_resource.id
   type     = "tmod:@turbot/azure#/policy/types/clientKey"
-  value    = "turbot application client key" //highlight-line
+  value    = "{Guardrails application client key}" 
 }
 
 resource "turbot_policy_setting" "clientId" {
   resource = turbot_resource.tenant_resource.id
   type     = "tmod:@turbot/azure#/policy/types/clientId"
-  value    = "turbot application client id" //highlight-line
+  value    = "{Guardrails application client id}" //highlight-line
 }
 
 resource "turbot_policy_setting" "tenantId" {
   resource = turbot_resource.tenant_resource.id
   type     = "tmod:@turbot/azure#/policy/types/tenantId"
-  value    = "tenant id" //highlight-line
+  value    = "{tenant id}" //highlight-line
 }
 ```

--- a/docs/integrations/azure/index.md
+++ b/docs/integrations/azure/index.md
@@ -12,30 +12,27 @@ nav:
 Turbot Guardrails is deeply integrated with
 [Microsoft Azure](https://azure.microsoft.com/).
 
-- Guardrails  provides dozens of Azure mods, with policies and controls for Azure
-  resource types.
+- Guardrails provides dozens of Azure mods, with policies and controls for many Azure resource types.
 - Guardrails extensive IAM integration allows you to federate Azure access and
   manage your Azure permissions through the Guardrails console and API.
-- Guardrails  event handlers/pollers keep the Guardrails CMDB up to date as Azure resources are
+- Guardrails event handlers/pollers keep the Guardrails CMDB up to date as Azure resources are
   created, modified and destroyed; allowing policy enforcement in real time.
-- Guardrails  shows all activity in your Azure subscriptions - you can quickly see
+- Guardrails shows all activity in your Azure subscriptions - you can quickly see
   what happened, who made the change, when the activity occurred, and exactly
   what changed.
 
 ## Getting started with Guardrails  for Azure
 
-1. Import Azure Resources. These are in the recommended order to import, but not
+1. Connect Azure Resources to Guardrails. These are in the recommended order to import, but not
    all sections will apply to all organizations:
 
-   - [Import Azure Tenant](integrations/azure/import/tenant)
-   - [Import Azure Active Directory](integrations/azure/import/active-directory)
-   - [Import Azure Management Group](integrations/azure/import/management-group)
-   - [Import Azure Subscription](integrations/azure/import/subscription)
+    - [Import Azure Tenant](integrations/azure/import/tenant)
+    - [Import Azure Active Directory](integrations/azure/import/active-directory)
+    - [Import Azure Management Group](integrations/azure/import/management-group)
+    - [Import Azure Subscription](integrations/azure/import/subscription)
 
-2. [Set up the Azure Real-Time Events](integrations/azure/real-time-events) to keep Turbot
-   CMDB up to date
-3. [Enable Azure Services](integrations/azure/services) that you will use
-4. [Configure Permissions Policies](integrations/azure/permissions) to allow Turbot to manage
+2. [Enable Azure Services](integrations/azure/services) that you will use
+3. [Configure Permissions Policies](integrations/azure/permissions) to allow Turbot to manage
    Azure permissions for your users
 
 ## Further Reading
@@ -43,4 +40,4 @@ Turbot Guardrails is deeply integrated with
 - Explore [Azure Mods](mods/)
 - Set up Turbot Azure policies with
   [Terraform Control Objectives](https://github.com/turbot/guardrails-samples/tree/master/control_objectives)
-- Learn more about [permissions in Turbot](concepts/iam/permissions)
+- Learn more about [permissions in Guardrails](concepts/iam/permissions)

--- a/docs/integrations/azure/real-time-events/ad-event-pollers.md
+++ b/docs/integrations/azure/real-time-events/ad-event-pollers.md
@@ -9,93 +9,16 @@ nav:
 
 # Active Directory Event Pollers
 
-The Turbot Azure Directory Poller control will query Audit Logs (Monitor) for
-relevant events on a schedule, and forward them to Turbot.
+The Guardrails Azure Directory Poller control will query Audit Logs (Monitor) for relevant events on a schedule, and
+forward them to Turbot. No additional configuration is required. They are enabled by default.
 
 ## Azure Active Directory Poller Turbot Policies
 
 The following policies will need to be configured to enable Azure AD Polling
 
 | Policy Type                                        | Description                                                                                                                                                                 |
-| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Azure > Turbot > Directory Event Poller            | Enable/ Disable polling                                                                                                                                                     |
 | Azure > Turbot > Directory Event Poller > Interval | The polling interval - how often to poll                                                                                                                                    |
 | Azure > Turbot > Directory Event Poller > Window   | The polling window - how far back to retrieve events when polling. This must exceed the interval, and is required in case events are received by Azure Monitor out of order |
 
-## Relevant policy schema
-
-### Azure > Turbot > Directory Event Poller
-
-```yml
-description: |
-  Configure the Azure Directory Event Poller.  When set to `Enabled`, the poller will run at the interval specified to retrieve the latest events and forward them to the Turbot Router.
-
-  Note: The Event Poller and Turbot Event Handler are different mechanisms for sending the same information to Turbot. You should enable one or the other, but typically not both. If you feel like you need to enable both, please contact Turbot support and we'll discuss your use case with you in depth.
-
-targets: Azure Active Directory
-
-schema:
-  type: string
-  enum:
-    - Enabled
-    - Disabled
-  default: Disabled
-```
-
-### Azure > Turbot > Directory Event Poller > Interval
-
-```yml
-description: |
-  The polling interval. This policy determines how often the event poller will run.
-
-targets: Azure Active Directory
-
-schema:
-  type: string
-  enum:
-    - Every 1 minute
-    - Every 2 minutes
-    - Every 3 minutes
-    - Every 4 minutes
-    - Every 5 minutes
-    - Every 6 minutes
-    - Every 7 minutes
-    - Every 8 minutes
-    - Every 9 minutes
-    - Every 10 minutes
-  default: Every 2 minute
-```
-
-### Azure > Turbot > Directory Event Poller > Window
-
-```yml
-description: |
-  The polling window, in minutes. This policies determines the oldest events the event poller will retrieve. For example, setting the window to '10 minutes' will cause the poller to retrieve all events from the previous 10 minutes every time it runs.
-
-  The Window must be greater than the Interval, and it is recommended to be at least twice the Interval. For example, if the Interval is 'Every 10 Minutes', the Window should be at least '20 Minutes'.
-
-targets: Azure Active Directory
-
-schema:
-  type: string
-  enum:
-    - 5 minutes
-    - 6 minutes
-    - 7 minutes
-    - 8 minutes
-    - 9 minutes
-    - 10 minutes
-    - 11 minutes
-    - 12 minutes
-    - 13 minutes
-    - 14 minutes
-    - 15 minutes
-    - 16 minutes
-    - 17 minutes
-    - 18 minutes
-    - 19 minutes
-    - 20 minutes
-    - 30 minutes
-    - 40 minutes
-  default: 10 minutes
-```

--- a/docs/integrations/azure/real-time-events/event-pollers.md
+++ b/docs/integrations/azure/real-time-events/event-pollers.md
@@ -9,91 +9,18 @@ nav:
 
 # Event Pollers
 
-The Turbot Azure Poller control will query Audit Logs (Monitor) for relevant
-events on a schedule, and forward them to the router for processing.
+The Guardrails Azure Poller control will query Audit Logs (Monitor) for relevant
+events on a schedule, and forward them to the router for processing. No additional configuration is required. Pollers
+are enabled by default.
 
 ## Azure Poller Turbot Policies
 
 The following policies will need to be configured to enable Azure Polling
 
 | Policy Type                              | Description                                                                                                                                                                 |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Azure > Turbot > Event Poller            | Enable/ Disable polling                                                                                                                                                     |
 | Azure > Turbot > Event Poller > Interval | The polling interval - how often to poll                                                                                                                                    |
 | Azure > Turbot > Event Poller > Window   | The polling window - how far back to retrieve events when polling. This must exceed the interval, and is required in case events are received by Azure Monitor out of order |
 
-## Relevant policy schema
 
-### Azure > Turbot > Event Poller
-
-```yml
-description: |
-  Configure the Azure Event Poller.  When set to `Enabled`, the poller will run at the interval specified to retrieve the latest events and forward them to the Turbot Router.
-
-  Note: The Event Poller and Turbot Event Handler are different mechanisms for sending the same information to Turbot. You should enable one or the other, but typically not both. If you feel like you need to enable both, please contact Turbot support and we'll discuss your use case with you in depth.
-
-targets: Azure Subscription
-
-schema:
-  type: string
-  enum:
-    - Enabled
-    - Disabled
-  default: Enabled
-```
-
-### Azure > Turbot > Event Poller > Interval
-
-```yml
-description: |
-  The polling interval. This policy determines how often the event poller will run.
-
-targets: Azure Subscription
-
-schema:
-  type: string
-  enum:
-    - Every 1 minute
-    - Every 2 minutes
-    - Every 3 minutes
-    - Every 4 minutes
-    - Every 5 minutes
-    - Every 6 minutes
-    - Every 7 minutes
-    - Every 8 minutes
-    - Every 9 minutes
-    - Every 10 minutes
-  default: Every 1 minute
-```
-
-### Azure > Turbot > Event Poller > Window
-
-```yml
-description: |
-  The polling window, in minutes. This policies determines the oldest events the event poller will retrieve. For example, setting the window to '5 minutes' will cause the poller to retrieve all events from the previous 5 minutes every time it runs.
-
-  The Window must be greater than the Interval, and it is recommended to be at least twice the Interval. For example, if the Interval is 'Every 5 Minutes', the Window should be at least '10 Minutes'.
-
-targets: Azure Subscription
-
-schema:
-  type: string
-  enum:
-    - 5 minutes
-    - 6 minutes
-    - 7 minutes
-    - 8 minutes
-    - 9 minutes
-    - 10 minutes
-    - 11 minutes
-    - 12 minutes
-    - 13 minutes
-    - 14 minutes
-    - 15 minutes
-    - 16 minutes
-    - 17 minutes
-    - 18 minutes
-    - 19 minutes
-    - 20 minutes
-  default: 10 minutes
-```

--- a/docs/integrations/azure/real-time-events/index.md
+++ b/docs/integrations/azure/real-time-events/index.md
@@ -2,38 +2,47 @@
 title: "Configuring Real-Time events"
 template: Documentation
 nav:
-    title: "Real-Time Events"
-    order: 20
+  title: "Real-Time Events"
+  order: 20
 ---
 
 # Configuring Real-Time Events
 
-We make use of events in order to keep Turbot up to date as Azure resources are created, destroyed, and modified. This allows policy enforcement in real time.
-Below are two ways to capture these events.
+Guardrails uses Azure Monitor events to keep up with Azure resources as they are created, destroyed, and modified. This
+allows policy enforcement in real time. Below are two ways to capture these events.
 
-  - Event Pollers
-  - Event Handlers
+- Event Pollers
+- Event Handlers
 
-**Event Handlers**:
-Guardrails Azure Event Handlers use push-based mechanism and are responsible for sending Azure events back to Guardrails for processing.
+## Event Pollers or Event Handlers
+
+Turbot Supports recommends using Azure Pollers in all circumstances.
+
+It is possible to configure both polling and event handlers, they should never be enabled at the same time.
+
+## Event Poller
+Guardrails Azure Event Pollers are a pull-based mechanism. They are enabled by default.  The pollers query Audit Logs (Azure Monitor) at regular intervals (every minute by default) for events inside the polling window (defaults to events in the last 10 minutes).
+
+## Event Handlers
+Guardrails Azure Event Handlers use push-based mechanism and are responsible for sending Azure events back to Guardrails
+for processing.
 
 The basic flow is as follows:
 
 - An API is invoked in the cloud provider, potentially making a change to a cloud resource.
 - The cloud provider writes it to their audit trail (Azure Monitor).
-- The Event Handler is connected the cloud provider's audit trail. As events are received, the Event Handler forwards them to the Guardrails event ingestion endpoint.
-- The Guardrails raw event endpoint decodes the token and runs the action specified by the action type ID. Typically, the action will run a provider router.
-- The provider router verifies and filters the requests, creates events specific to that provider and pushes them onto the event bus.
-- Typically, a resource router will pick up the event and take the appropriate action (e.g., - if the event is due to the creation of a resource, that resource will be upserted into the database)
-- Event Handlers **require** the Microsoft Insights provider is registered within the imported Subscription. Attempting to configure event handlers without registering Microsoft Insights will result in errors and events not flowing back to Guardrails!
+- The Event Handler is connected the cloud provider's audit trail. As events are received, the Event Handler forwards
+  them to the Guardrails event ingestion endpoint.
+- The Guardrails raw event endpoint decodes the token and runs the action specified by the action type ID. Typically,
+  the action will run a provider router.
+- The provider router verifies and filters the requests, creates events specific to that provider and pushes them onto
+  the event bus.
+- Typically, a resource router will pick up the event and take the appropriate action (e.g., - if the event is due to
+  the creation of a resource, that resource will be upserted into the database)
+- Event Handlers **require** the Microsoft Insights provider is registered within the imported Subscription. Attempting
+  to configure event handlers without registering Microsoft Insights will result in errors and events not flowing back
+  to Guardrails!
 
-**Event Poller**:
-Guardrails Azure Event Pollers are a pull-based mechanism. The pollers query Audit Logs (Azure Monitor) at intervals specified and retrieves the latest events (Succeeded) for processing.
 
-## Pollers or Handlers
-Organizational requirements generally dictate whether pollers or handlers will be used.  Turbot Supports recommends using Azure Event Handlers for increased efficiency.
 
-* Choose Polling for ease of configuration or when no Guardrails managed resources can be deployed in the subscription. 
-* Choose Event Handlers for efficiency and timeliness. 
 
-While it is possible to configure both polling and event handlers, they should never be enabled at the same time.

--- a/docs/integrations/azure/real-time-events/mgmt-event-pollers.md
+++ b/docs/integrations/azure/real-time-events/mgmt-event-pollers.md
@@ -1,5 +1,5 @@
 ---
-title: "Azure Polling"
+title: "Azure Management Group Event Polling"
 sidebar_label: "Mgmt Event Polling"
 template: Documentation
 nav:
@@ -9,57 +9,15 @@ nav:
 
 # Management Group Event Pollers
 
-The Turbot Azure Management Group Poller control will run at specified interval
-to run the Management Group discovery to look for changes in the Management
-Group hierarchy.
+The Guardrails Azure Management Group Poller control will run at specified interval (defaults to every 12 hours)
+to run the Management Group discovery to look for changes in the Management Group hierarchy.
 
 ## Azure Management Group Poller Turbot Policies
 
-The following policies will need to be configured to enable Azure Management
-Group Polling
+The following policies dictate the behavior of the Azure Management Group Polling. No additional configuration is
+required. They are enabled by default.
 
 | Policy Type                                               | Description                                                              |
-| --------------------------------------------------------- | ------------------------------------------------------------------------ |
+|-----------------------------------------------------------|--------------------------------------------------------------------------|
 | Azure > Turbot > Management Group Event Poller            | Enable/ Disable polling                                                  |
 | Azure > Turbot > Management Group Event Poller > Interval | The polling interval - how often the Management Group discovery will run |
-
-## Relevant policy schema
-
-### Azure > Turbot > Management Group Event Poller
-
-```yml
-description: |
-  Configure the Azure Event Poller.  When set to `Enabled`, the poller will run at the interval specified to run the Management Group discovery control to look for changes in the Management Group hierarchy.
-
-targets: Azure Management Group
-
-schema:
-  type: string
-  enum:
-    - Enabled
-    - Disabled
-  default: Disabled
-```
-
-### Azure > Turbot > Management Group Event Poller > Interval
-
-```yml
-description: |
-  The discovery run interval. This policy determines how often the management group discovery will run.
-
-targets: Azure Management Group
-
-schema:
-  type: string
-  enum:
-    - Every hour
-    - Every 2 hours
-    - Every 3 hours
-    - Every 6 hours
-    - Every 12 hours
-    - Every day
-    - Every 2 days
-    - Every 3 days
-    - Every week
-  default: Every 12 hours
-```


### PR DESCRIPTION
Azure API and IAM Permissions
- Consolidated the Azure IAM permissions down to a single custom role that works for Tenants, Management Groups and Subscriptions 
- Simplified Graph API permissions. 
- Simplified language describing the import process.
- Updated Management Group Pollers to show that they are enabled by default.