### PR TITLE
Clarify aws decommission docs

### DIFF
--- a/docs/integrations/aws/decommission/index.md
+++ b/docs/integrations/aws/decommission/index.md
@@ -9,12 +9,14 @@ nav:
 
 As a part of Guardrails workspace maintenance, AWS accounts need to be removed. There are two parts to this process:
 
-1. [Decommission Guardrails-managed resources](#decommission-guardrails-infrastructure) in the AWS account, where desired. Altering the relevant policy settings
+1. [Decommission Guardrails-managed resources](#decommission-guardrails-infrastructure) in the AWS account, where
+   desired. Altering the relevant policy settings
    will
    make changes in the AWS account. Administrators should determine if they would like to keep
    Guardrails-managed resources in the account, such as S3 buckets, or CloudTrail. Event Handlers should always be
    removed.
-2. [Disconnect the AWS account from Guardrails](#disconnect-aws-account-from-guardrails) . This is Guardrails-side only change. No changes are made in the AWS
+2. [Disconnect the AWS account from Guardrails](#disconnect-aws-account-from-guardrails) . This is Guardrails-side only
+   change. No changes are made in the AWS
    account.
 
 Note that disconnecting an AWS account from Guardrails will remove all child CMDB records and policy settings.
@@ -23,7 +25,8 @@ Note that disconnecting an AWS account from Guardrails will remove all child CMD
 
 To ensure complete cleanup of Guardrails-managed resources, create the policy settings below with the
 prescribed values. If you wish to retain those resources, do not create the policy setting. Time should be allowed for
-Guardrails to complete the removal process for these resources.
+Guardrails to complete the removal process for these resources. It is safe to create these policy settings, even if
+there is no corresponding `Enforce: Enabled`
 
 1. `AWS > Turbot > Permissions` set to `Enforce: None`. This will remove Guardrails-managed
    IAM policies, groups, roles and users.
@@ -49,7 +52,7 @@ Guardrails to complete the removal process for these resources.
    the account.
 
 Once the controls associated with the above policies have completed, the AWS
-account can be disconnected from the Guardrails workspace. 
+account can be disconnected from the Guardrails workspace.
 
 ## Disconnect AWS Account from Guardrails
 
@@ -92,12 +95,12 @@ number of resources in the account. The general aim is to reduce the number of r
 
 ### Automated Resource Count Reduction
 
-1. Use
-   the `aws_account_delete` [script in the Guardrails Samples Repo (GSR)](https://github.com/turbot/guardrails-samples/tree/main/guardrails_utilities/python_utils/remove_aws_account)
+1. Use the
+   `aws_account_delete` [script in the Guardrails Samples Repo (GSR)](https://github.com/turbot/guardrails-samples/tree/main/guardrails_utilities/python_utils/remove_aws_account)
    to automate the process of creating the CMDB policy settings and disconnecting the account.
 2. Refer to
    the [README](https://github.com/turbot/guardrails-samples/blob/main/guardrails_utilities/python_utils/remove_aws_account/README.md)
-   for further instructions on how to setup and run the script.
+   for further instructions on how to set up and run the script.
 
 It may take several attempts to delete the account. If the account cannot be disconnected even after drastic reductions
 in resource counts, please open a ticket with [Turbot Support](mailto:help@turbot.com) for further assistance.
@@ -107,6 +110,5 @@ in resource counts, please open a ticket with [Turbot Support](mailto:help@turbo
 When a user with sufficient permissions attempts to disconnect an AWS account, Guardrails will try to remove the
 account, all child resources, controls, policy settings in a single SQL transactions. This is done for safety. Should
 the transaction fail, it's trivial for the database to roll back to a known good state. The effect of this rollback is
-that the account
-remains visible in Guardrails. AWS accounts with larger numbers of resources, the time required to complete
-the transaction may exceed the statement timeout limit. 
+that the account remains visible in Guardrails. AWS accounts with larger numbers of resources, the time required to
+complete the transaction may exceed the statement timeout limit. 

--- a/docs/integrations/aws/decommission/index.md
+++ b/docs/integrations/aws/decommission/index.md
@@ -1,38 +1,47 @@
 ---
-title: Decommission Account out of Guardrails Workspace
+title: Disconnect Account from Guardrails Workspace
 template: Documentation
 nav:
   order: 50
 ---
 
-# Decommission an AWS account out of a Guardrails workspace
+# Disconnect an AWS account from a Guardrails workspace
 
-Turbot Guardrails natively allows a Guardrails administrator to remove an AWS account from a workspace.
-The delete action removes any associated policies and references in the
-Guardrails CMDB, but NO RESOURCES ARE DELETED FROM THE TARGET ACCOUNT. Careful
-consideration must be made when removing resources within the account, as once
-data is deleted, such as CloudTrail and logs in S3, it cannot be restored.
+As a part of Guardrails workspace maintenance, AWS accounts need to be removed. There are two parts to this process:
 
-Before the delete process is started, administrators will want to determine if
-they would like to keep Guardrails-managed resources in the account, such as S3 buckets, or CloudTrail. 
-The following policies can be set at the AWS account within the Guardrails workspace to
-facilitate cleanup. Be sure to verify that the exceptions are being set ONLY on the account that will be removed.
+1. [Decommission Guardrails-managed resources](#decommission-guardrails-infrastructure) in the AWS account, where desired. Altering the relevant policy settings
+   will
+   make changes in the AWS account. Administrators should determine if they would like to keep
+   Guardrails-managed resources in the account, such as S3 buckets, or CloudTrail. Event Handlers should always be
+   removed.
+2. [Disconnect the AWS account from Guardrails](#disconnect-aws-account-from-guardrails) . This is Guardrails-side only change. No changes are made in the AWS
+   account.
+
+Note that disconnecting an AWS account from Guardrails will remove all child CMDB records and policy settings.
+
+## Decommission Guardrails Infrastructure
+
+To ensure complete cleanup of Guardrails-managed resources, create the policy settings below with the
+prescribed values. If you wish to retain those resources, do not create the policy setting. Time should be allowed for
+Guardrails to complete the removal process for these resources.
 
 1. `AWS > Turbot > Permissions` set to `Enforce: None`. This will remove Guardrails-managed
-   IAM policies, groups, roles and users. 
+   IAM policies, groups, roles and users.
 2. `AWS > Turbot > Audit Trail` set to `Enforce: Not configured`. This will
    remove the Guardrails-managed CloudTrail.
 3. `AWS > Turbot > Event Handlers` set to `Enforce: Not configured`. This will
    remove Guardrails-managed Cloudwatch Event Rules and SNS topics. Refer to the
    [Event Handler documentation](integrations/aws/event-handlers) for additional
    context.
-4. `AWS > Turbot > Service Roles` set to `Enforce: Not configured`. This will
+4. `AWS > Turbot > Event Handlers [Global]` set to `Enforce: Not configured`. This will
+   remove Guardrails-managed Cloudwatch Event Rules and SNS topics.
+5. `AWS > Turbot > Service Roles` set to `Enforce: Not configured`. This will
    remove any Guardrails-managed IAM service roles.
-5. `AWS > Turbot > Logging > Bucket` set to `Enforce: Not configured`. This will
-   remove Guardrails-managed logging S3 buckets.  Note: Logging buckets cannot be deleted
+6. `AWS > Turbot > Logging > Bucket` set to `Enforce: Not configured`. This will
+   remove Guardrails-managed logging S3 buckets. Note: Logging buckets cannot be deleted
    if they are not empty. Administrators can empty the bucket using the AWS
    console.
-6. `AWS > Turbot > Event Poller` to `Disabled`. When event handlers are set to
+7. `AWS > Turbot > Event Poller` to `Disabled`. When event handlers are set to
    `Skip` or `Enforce: Not Configured`, Polling is automatically enabled. It
    must be explicitly disabled. Note that full cleanup of event handler
    resources requires event pollers to still be active. Disable Event Pollers
@@ -40,10 +49,9 @@ facilitate cleanup. Be sure to verify that the exceptions are being set ONLY on 
    the account.
 
 Once the controls associated with the above policies have completed, the AWS
-account can be deleted from the Guardrails workspace. Any combination of the policies can be used
-to target specific resources while leaving important audit logging data available.
+account can be disconnected from the Guardrails workspace. 
 
-## Steps to remove an account from Guardrails
+## Disconnect AWS Account from Guardrails
 
 Prior to performing the below steps, delete the policies
 `AWS > Account > Turbot IAM Role > External ID` and
@@ -60,16 +68,45 @@ have been removed, the account can be deleted from Guardrails.
    depend on the number of resources and policies that will be removed. The more
    resources that are being deleted, the longer the process will take.
 
-A time-out error may occur when deleting an account; the delete function is a complex SQL
-transaction, and failures in referential integrity or other blocking/locking
-database activity can cause the delete to fail.  Should the account delete transaction timeout,
-the Guardrails DB will roll back the transaction and the account remains in the workspace.
+## Troubleshooting
 
-If an error message is encountered, ensure that AWS event handlers
-for that account have been removed in all regions so no new transactions are incoming,
-remove the policy settings at the account level that contain the security
-credentials Guardrails uses to access the account, and try again. It may take
-several attempts to delete the account. If the deletion error persists for more
-than several hours after removing the event handlers, and you have verified that
-no account activity is taking place in the `Activity` tab, please open a ticket
-with Turbot Support.
+The disconnection step may time out due to a number of factors including but not limited to overall system load, and the
+number of resources in the account. The general aim is to reduce the number of resources in the account.
+
+### Manual Resource Count Reduction
+
+1. From the Guardrails landing page, find the AWS Account to be disconnected.
+2. On the Account resource page, go to the little **Reports** tab. Look at the "Top Resource Types" on the left side.
+   These are the resource to target first.
+3. Switch back to the little **Policies** tab. Click the green "New Policy Setting" button.
+4. Search for the CMDB policy for the top resource type. It will be in the form
+   of `AWS > {Service} > {Resource Type} > CMDB`.
+5. The Resource field should already be set to the AWS Account to be disconnected.
+6. Set the CMDB policy to `Enforce: Disabled`. This will instruct Guardrails to purge all resource records for this
+   resource type.
+7. Click the "Create" button.
+8. Over the next few minutes Guardrails will purge those resource CMDB entries and the overall resource count in the
+   account will go down.
+9. Attempt to disconnect the account. If this times out, continue steps 3 through 8 until the account is successfully
+   disconnected.
+
+### Automated Resource Count Reduction
+
+1. Use
+   the `aws_account_delete` [script in the Guardrails Samples Repo (GSR)](https://github.com/turbot/guardrails-samples/tree/main/guardrails_utilities/python_utils/remove_aws_account)
+   to automate the process of creating the CMDB policy settings and disconnecting the account.
+2. Refer to
+   the [README](https://github.com/turbot/guardrails-samples/blob/main/guardrails_utilities/python_utils/remove_aws_account/README.md)
+   for further instructions on how to setup and run the script.
+
+It may take several attempts to delete the account. If the account cannot be disconnected even after drastic reductions
+in resource counts, please open a ticket with [Turbot Support](mailto:help@turbot.com) for further assistance.
+
+## How Disconnection Works
+
+When a user with sufficient permissions attempts to disconnect an AWS account, Guardrails will try to remove the
+account, all child resources, controls, policy settings in a single SQL transactions. This is done for safety. Should
+the transaction fail, it's trivial for the database to roll back to a known good state. The effect of this rollback is
+that the account
+remains visible in Guardrails. AWS accounts with larger numbers of resources, the time required to complete
+the transaction may exceed the statement timeout limit. 


### PR DESCRIPTION
Updates to the AWS Disconnection docs
- Increased clarity on the preparation process
- Shows how to reduce resource counts manually.
- Shows how to reduce resource counts by script. 
- "How It Works" section describes what's going on under the covers. 

Related Policy Pack PR: https://github.com/turbot/guardrails-samples/pull/834